### PR TITLE
Upgrade use of template variables to be compatible with Django > 1.8

### DIFF
--- a/localeurl/templatetags/localeurl_tags.py
+++ b/localeurl/templatetags/localeurl_tags.py
@@ -1,8 +1,8 @@
 from django import template
+from django.conf.urls import url
 from django.template.base import Node, Token, TemplateSyntaxError
-from django.template import resolve_variable
+from django.template import Variable
 from django.template.defaultfilters import stringfilter
-from django.templatetags import future
 
 from localeurl import utils
 
@@ -52,7 +52,7 @@ def locale_url(parser, token):
         raise TemplateSyntaxError("'%s' takes at least two arguments:"
                 " the locale and a view" % bits[0])
     urltoken = Token(token.token_type, bits[0] + ' ' + ' '.join(bits[2:]))
-    urlnode = future.url(parser, urltoken)
+    urlnode = url(parser, urltoken)
     return LocaleURLNode(bits[1], urlnode)
 
 
@@ -62,7 +62,7 @@ class LocaleURLNode(Node):
         self.urlnode = urlnode
 
     def render(self, context):
-        locale = resolve_variable(self.locale, context)
+        locale = Variable(self.locale).resolve(context)
         if utils.supported_language(locale) is None:
             raise ValueError("locale not in settings.LANGUAGES: %s" % locale)
         path = self.urlnode.render(context)


### PR DESCRIPTION
Update the use of template variables to be compatible with Django 1.11.

It will be used in the apprl project referencing this branch, this PR will be open to remember us to merge it after the upgrade.


Merge after https://github.com/apprl/apprl/pull/1146